### PR TITLE
高速化実験

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,12 @@ services:
       - .:/home/circleci:cached
       - rails_cache:/home/circleci/tmp/cache
       - bundler:/usr/local/bundle
+      # exclude volumes
+      - /home/circleci/vendor
+      - /home/circleci/tmp
+      - /home/circleci/log
+      - /home/circleci/.git
+      - /home/circleci/node_modules
     working_dir: /home/circleci
     user: root
     ports:


### PR DESCRIPTION
マウントを解除するなどしてちょっとだけ高速化してみた。

## Before

```
kakikubo@kair2020 ~/Documents/taskleaf % time dip rspec
[+] Running 2/0
 ⠿ Container taskleaf-redis-1  Running                                                                                                                                                       0.0s
 ⠿ Container taskleaf-pgsql-1  Running                                                                                                                                                       0.0s
Ignoring debase-0.2.5.beta2 because its extensions are not built. Try: gem pristine debase --version 0.2.5.beta2
Ignoring io-console-0.5.11 because its extensions are not built. Try: gem pristine io-console --version 0.5.11
.....................*..*.........................2022-02-26 07:58:06 WARN Selenium [DEPRECATION] [:browser_options] :options as a parameter for driver initialization is deprecated. Use :capabilities with an Array of value capabilities/options if necessary instead.
...........

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) SampleJob add some examples to (or delete) /home/circleci/spec/jobs/sample_job_spec.rb
     # Not yet implemented
     # ./spec/jobs/sample_job_spec.rb:6

  2) Contact add some examples to (or delete) /home/circleci/spec/models/contact_spec.rb
     # Not yet implemented
     # ./spec/models/contact_spec.rb:6


Finished in 37.92 seconds (files took 1 minute 54.97 seconds to load)
61 examples, 0 failures, 2 pending

Coverage report generated for RSpec to /home/circleci/coverage. 147 / 173 LOC (84.97%) covered.
Lcov style coverage report generated for RSpec to coverage/lcov.info
dip rspec  0.29s user 0.12s system 0% cpu 2:46.75 total
```

## After

```
kakikubo@kair2020 ~/Documents/taskleaf % time dip rspec
[+] Running 2/0
 ⠿ Container taskleaf-redis-1  Created                                                                                                                                                       0.0s
 ⠿ Container taskleaf-pgsql-1  Created                                                                                                                                                       0.0s
[+] Running 2/2
 ⠿ Container taskleaf-pgsql-1  Started                                                                                                                                                       0.5s
 ⠿ Container taskleaf-redis-1  Started                                                                                                                                                       0.5s
Ignoring debase-0.2.5.beta2 because its extensions are not built. Try: gem pristine debase --version 0.2.5.beta2
Ignoring io-console-0.5.11 because its extensions are not built. Try: gem pristine io-console --version 0.5.11
.....................*..*.........................2022-02-26 08:12:28 WARN Selenium [DEPRECATION] [:browser_options] :options as a parameter for driver initialization is deprecated. Use :capabilities with an Array of value capabilities/options if necessary instead.
...........

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) SampleJob add some examples to (or delete) /home/circleci/spec/jobs/sample_job_spec.rb
     # Not yet implemented
     # ./spec/jobs/sample_job_spec.rb:6

  2) Contact add some examples to (or delete) /home/circleci/spec/models/contact_spec.rb
     # Not yet implemented
     # ./spec/models/contact_spec.rb:6


Finished in 20.36 seconds (files took 1 minute 26.87 seconds to load)
61 examples, 0 failures, 2 pending

Coverage report generated for RSpec to /home/circleci/coverage. 147 / 173 LOC (84.97%) covered.
Lcov style coverage report generated for RSpec to coverage/lcov.info
dip rspec  0.29s user 0.26s system 0% cpu 2:09.89 total
```
