### PR TITLE
chore/git pr release jst

### DIFF
--- a/.github/workflows/git-pr-release.yml
+++ b/.github/workflows/git-pr-release.yml
@@ -28,5 +28,5 @@ jobs:
         GIT_PR_RELEASE_BRANCH_STAGING: develop
         GIT_PR_RELEASE_LABELS: release
       run: |
-        gem install -N git-pr-release -v "1.9.0"
+        gem install -N git-pr-release -v "2.2.0"
         git-pr-release --no-fetch


### PR DESCRIPTION
- **3.3対応とJST対応**
- **git-pr-releaseのバージョンアップ1.9.0->2.2.0**
