### PR TITLE
chore/remove rubocop todo

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,13 +35,6 @@ RSpec/AnyInstance:
     - 'spec/jobs/sample_job_spec.rb'
 
 # Offense count: 1
-# Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
-# Include: **/*_spec*rb*, **/spec/**/*
-RSpec/FilePath:
-  Exclude:
-    - 'spec/controllers/users_controller_spec.rb'
-
-# Offense count: 1
 # Configuration parameters: .
 # SupportedStyles: have_received, receive
 RSpec/MessageSpies:


### PR DESCRIPTION
- **SpecFilePathFormatがすでに指摘箇所自体がなくなっている為、削除**
- **RSpec/FilePathもすでに指摘箇所がなくなっていたので削除**
