### PR TITLE
tasks.created_at にデータベースインデックスを追加

### DIFF
--- a/db/migrate/20260411080303_add_index_to_tasks_created_at.rb
+++ b/db/migrate/20260411080303_add_index_to_tasks_created_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToTasksCreatedAt < ActiveRecord::Migration[8.1]
+  def change
+    add_index :tasks, :created_at
+  end
+end

--- a/db/migrate/20260411080303_add_index_to_tasks_created_at.rb
+++ b/db/migrate/20260411080303_add_index_to_tasks_created_at.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddIndexToTasksCreatedAt < ActiveRecord::Migration[8.1]
   def change
     add_index :tasks, :created_at

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,28 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2022_03_05_085742) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_11_080303) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum"
+    t.string "content_type"
     t.datetime "created_at", precision: nil, null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -43,28 +43,29 @@ ActiveRecord::Schema[7.1].define(version: 2022_03_05_085742) do
   end
 
   create_table "contacts", force: :cascade do |t|
-    t.string "name"
-    t.string "email"
     t.datetime "created_at", null: false
+    t.string "email"
+    t.string "name"
     t.datetime "updated_at", null: false
   end
 
   create_table "tasks", force: :cascade do |t|
-    t.string "name", limit: 30, null: false
-    t.text "description"
     t.datetime "created_at", precision: nil, null: false
+    t.text "description"
+    t.string "name", limit: 30, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "user_id", null: false
+    t.index ["created_at"], name: "index_tasks_on_created_at"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "email", null: false
-    t.string "password_digest", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.boolean "admin", default: false, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.string "email", null: false
+    t.string "name", null: false
+    t.string "password_digest", null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## Summary
- `tasks.created_at` カラムにデータベースインデックスを追加
- `scope :recent` や Ransack による `created_at` でのソート/検索パフォーマンスを向上

## Test plan
- [x] マイグレーションが正常に実行される
- [x] `db/schema.rb` に `index_tasks_on_created_at` が追加される
- [x] 既存のモデルテストがパスする

Closes #1559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * タスク関連のデータベースクエリのパフォーマンスを向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->