### PR TITLE
special_time?メソッドのロジックを修正する

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -72,6 +72,7 @@ class TasksController < ApplicationController
   end
 
   def special_time?
-    Time.current.all_day.cover?(ANNIVERSARY_DATE)
+    today = Date.current
+    today.month == ANNIVERSARY_DATE.month && today.day == ANNIVERSARY_DATE.day
   end
 end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -40,6 +40,30 @@ describe Task do
         expect(response.body).to include 'お誕生日おめでとうございます'
       end
     end
+
+    context '記念日の年が異なる場合' do
+      before do
+        travel_to(Time.zone.parse('2026-03-13')) do
+          get '/tasks'
+        end
+      end
+
+      it '年が異なっても月日が同じならバースデーメッセージが出力される' do
+        expect(response.body).to include 'お誕生日おめでとうございます'
+      end
+    end
+
+    context '記念日でない日の場合' do
+      before do
+        travel_to(Time.zone.parse('2026-04-01')) do
+          get '/tasks'
+        end
+      end
+
+      it 'バースデーメッセージが出力されない' do
+        expect(response.body).not_to include 'お誕生日おめでとうございます'
+      end
+    end
   end
 
   context 'ログインしていない場合' do


### PR DESCRIPTION
## Summary
- `special_time?`メソッドが年をまたいだ記念日を正しく判定できないバグを修正
- `Time.current.all_day.cover?(ANNIVERSARY_DATE)` を月日のみの比較に変更
- 年違い・非記念日のテストケースを追加

## Test plan
- [x] 2020-03-13（元の記念日）でメッセージが表示されること
- [x] 2026-03-13（年違い）でもメッセージが表示されること
- [x] 2026-04-01（非記念日）ではメッセージが表示されないこと
- [x] 全53テストがパスすること

closes #1562