### PR TITLE
confirm_destroyでfind_byをfindに統一する

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -50,7 +50,7 @@ class TasksController < ApplicationController
   end
 
   def confirm_destroy
-    @task = current_user.tasks.find_by(id: params.require(:task_id))
+    @task = current_user.tasks.find(params.require(:task_id))
   end
 
   def destroy


### PR DESCRIPTION
## Summary
- `TasksController#confirm_destroy` で `find_by` を `find` に変更
- 存在しない `task_id` が渡された場合に `ActiveRecord::RecordNotFound` が発生し、404が返るようになる
- 他のアクション（`show`, `edit`, `update`, `destroy`）と一貫した挙動になる

Closes #1558

## Test plan
- [x] 存在するタスクIDで削除確認画面が正常に表示されること
- [x] 存在しないタスクIDで404が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)