### PR TITLE
ApplicationController の FIXME コメントを削除する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@
 
 class ApplicationController < ActionController::Base
   helper_method :current_user
-  before_action :login_required # FIXME: Controller Specをテストする間は一時的にコメントアウト
+  before_action :login_required
 
   private
 


### PR DESCRIPTION
## Summary
- `ApplicationController` の `before_action :login_required` 行に残っていた解決済みの FIXME コメントを削除

Closes #1557

## Test plan
- [x] メインリポジトリで `bundle exec rspec spec/controllers/ spec/requests/` が全件パス (97 examples, 0 failures)
- コメント削除のみのため、動作への影響なし