### PR TITLE
fix(mailer): TaskMailer の送信先を動的化 (#1549)

### DIFF
--- a/app/mailers/task_mailer.rb
+++ b/app/mailers/task_mailer.rb
@@ -7,7 +7,7 @@ class TaskMailer < ApplicationMailer
     @task = task
     mail(
       subject: I18n.t('task_created_subject'),
-      to: 'user@example.com'
+      to: @task.user.email
     )
   end
 end

--- a/spec/mailers/task_mailer_spec.rb
+++ b/spec/mailers/task_mailer_spec.rb
@@ -4,14 +4,15 @@ require 'rails_helper'
 
 RSpec.describe TaskMailer do
   describe '#creation_email' do
-    let(:task) { create(:task, name: 'メイラーSpecを書く', description: '送信したメールの内容を確認します') }
+    let(:user) { create(:user, email: 'owner@example.com') }
+    let(:task) { create(:task, user:, name: 'メイラーSpecを書く', description: '送信したメールの内容を確認します') }
     let(:mail) { described_class.creation_email(task) }
     let(:text_body) { mail.text_part.body.raw_source }
     let(:html_body) { mail.html_part.body.raw_source }
 
     it 'sends an email with expected headers and body' do
       expect(mail.subject).to eq('タスク作成完了メール')
-      expect(mail.to).to eq(['user@example.com'])
+      expect(mail.to).to eq(['owner@example.com'])
       expect(mail.from).to eq(['taskleaf@example.com'])
 
       expect(text_body).to include('以下のタスクを作成しました')

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -144,7 +144,7 @@ describe Task do
       end
 
       it 'メールの宛先が正しいこと' do
-        expect(last_email).to be_delivered_to 'user@example.com'
+        expect(last_email).to be_delivered_to 'admin@example.com'
       end
 
       it 'メールの送信元が正しいこと' do


### PR DESCRIPTION
## Summary
- `TaskMailer#creation_email` の宛先をハードコードの `user@example.com` から `@task.user.email` に変更
- 対応する mailer spec を更新

Closes #1549

## Test plan
- [x] `bundle exec rspec spec/mailers/task_mailer_spec.rb`
- [x] `bundle exec rubocop app/mailers/task_mailer.rb spec/mailers/task_mailer_spec.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* タスク作成通知メールの送信先が、ハードコードされた固定アドレスから実際のタスク関連ユーザーのメールアドレスに修正されました。これにより、通知が正しいユーザーに確実に届くようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->