### PR TITLE
Content Security Policy を有効化 (#1550)

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,22 +6,22 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self, :https
+    policy.style_src   :self, :https, :unsafe_inline
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w[script-src style-src]
+
+  # Report violations without enforcing the policy.
+  # config.content_security_policy_report_only = true
+end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -18,8 +18,8 @@ Rails.application.configure do
     # policy.report_uri "/csp-violation-report-endpoint"
   end
 
-  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  # Generate per-request random nonces for permitted importmap, inline scripts, and inline styles.
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
   config.content_security_policy_nonce_directives = %w[script-src style-src]
 
   # Report violations without enforcing the policy.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -8,12 +8,12 @@
 
 Rails.application.configure do
   config.content_security_policy do |policy|
-    policy.default_src :self, :https
-    policy.font_src    :self, :https, :data
-    policy.img_src     :self, :https, :data
+    policy.default_src :self
+    policy.font_src    :self, :data
+    policy.img_src     :self, :data
     policy.object_src  :none
-    policy.script_src  :self, :https
-    policy.style_src   :self, :https, :unsafe_inline
+    policy.script_src  :self
+    policy.style_src   :self
     # Specify URI for violation reports
     # policy.report_uri "/csp-violation-report-endpoint"
   end


### PR DESCRIPTION
## 概要

`config/initializers/content_security_policy.rb` がコメントアウトされており CSP ヘッダーが送出されていなかったため、XSS 防御レイヤーとして CSP を有効化しました。

## 変更内容

- `content_security_policy.rb` のコメントアウトを解除
- ディレクティブは Issue #1550 の提案に準拠
  - `default_src :self, :https`
  - `font_src / img_src` に `:data` を許可
  - `object_src :none`
  - `script_src :self, :https`
  - `style_src :self, :https, :unsafe_inline`（Bootstrap のインラインスタイル用）
- `script-src` / `style-src` に nonce ジェネレータを設定（importmap・インラインスクリプト用）

## 補足

- ビューや importmap は外部 CDN を参照しておらず、すべて self ホストのため `:self` ベースで問題なし
- `csp_meta_tag` はレイアウトに既設のため追加対応不要

## Test plan

- [x] `bundle exec rubocop config/initializers/content_security_policy.rb` 通過
- [x] `Rails.application.config.content_security_policy.directives` で意図した内容を確認
- [ ] レビュー後、ブラウザで CSP ヘッダー・各画面の表示を確認

Closes #1550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **その他**
  * アプリ全体のコンテンツセキュリティポリシーを有効化し、許可範囲を厳格化しました（スクリプト／スタイルの外部読み込みを制限、フォント／画像の扱いを明確化）。加えて、Nonceの生成をより安全な方式に更新してリクエスト単位で管理するようにしました。レポート関連の設定は引き続きコメント化したままです。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->