### PR TITLE
CSV インポートにトランザクションとエラーハンドリングを追加

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -16,8 +16,12 @@ class TasksController < ApplicationController
   end
 
   def import
-    current_user.tasks.import(params[:file])
-    redirect_to tasks_url, notice: I18n.t('task_created')
+    errors = current_user.tasks.import(params[:file])
+    if errors.empty?
+      redirect_to tasks_url, notice: I18n.t('task_created')
+    else
+      redirect_to tasks_url, alert: "インポートに失敗しました: #{errors.join(' / ')}"
+    end
   end
 
   def show; end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -34,13 +34,20 @@ class Task < ApplicationRecord
     end
 
     def import(file)
-      return unless file
+      return [] unless file
 
-      CSV.foreach(file.path, headers: true) do |row|
-        task = new
-        task.attributes = row.to_hash.slice(*csv_attributes)
-        task.save!
+      errors = []
+      transaction do
+        CSV.foreach(file.path, headers: true).with_index(2) do |row, line|
+          task = new
+          task.attributes = row.to_hash.slice(*csv_attributes)
+          next if task.save
+
+          errors << "#{line}行目: #{task.errors.full_messages.join(', ')}"
+        end
+        raise ActiveRecord::Rollback if errors.any?
       end
+      errors
     end
 
     def ransackable_attributes(_auth_object = nil)

--- a/spec/fixtures/files/tasks_invalid.csv
+++ b/spec/fixtures/files/tasks_invalid.csv
@@ -1,0 +1,3 @@
+name,description,created_at,updated_at
+valid task,desc,2023-05-02 22:41:43 UTC,2023-05-02 22:41:43 UTC
+,missing name row,2023-05-02 22:41:43 UTC,2023-05-02 22:41:43 UTC

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -79,6 +79,25 @@ RSpec.describe Task do
 
       expect(described_class.last.name).to eq('uploader')
     end
+
+    it 'returns an empty array on success' do
+      expect(user.tasks.import(file)).to eq([])
+    end
+
+    context 'when the CSV contains an invalid row' do
+      let!(:user) { create(:user) }
+      let(:invalid_file) { fixture_file_upload('tasks_invalid.csv', 'text/csv') }
+
+      it 'rolls back all rows and returns errors' do
+        result = nil
+        expect do
+          result = user.tasks.import(invalid_file)
+        end.not_to change(described_class, :count)
+
+        expect(result).not_to be_empty
+        expect(result.first).to include('行目')
+      end
+    end
   end
 
   describe '.ransackable_attributes' do

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -408,6 +408,26 @@ describe Task do
       end
     end
 
+    context '不正な行を含むCSVファイルをアップロードする場合' do
+      let(:invalid_file) { fixture_file_upload('spec/fixtures/files/tasks_invalid.csv', 'text/csv') }
+
+      it 'タスクが増加しないこと（全件ロールバック）' do
+        expect do
+          post import_tasks_path, params: { file: invalid_file }
+        end.not_to change(described_class, :count)
+      end
+
+      it 'タスク一覧画面にリダイレクトされること' do
+        post import_tasks_path, params: { file: invalid_file }
+        expect(response).to redirect_to tasks_path
+      end
+
+      it 'エラー内容を含むフラッシュメッセージが表示されること' do
+        post import_tasks_path, params: { file: invalid_file }
+        expect(flash[:alert]).to include 'インポートに失敗しました'
+      end
+    end
+
     context 'ファイルを選択せずにインポートする場合' do
       it 'タスクが増加しないこと' do
         expect do


### PR DESCRIPTION
## Summary
- `Task.import` を transaction で囲み、不正な行があれば全件ロールバックするようにしました
- 各行のバリデーションエラーを行番号付きで収集して呼び出し元に返します
- `TasksController#import` でエラーがあればフラッシュに表示し、500 エラーを返さないようにしました

Closes #1551

## Test plan
- [x] `bundle exec rspec spec/models/task_spec.rb spec/models/task_validation_edge_cases_spec.rb`
- [x] `bundle exec rubocop app/models/task.rb app/controllers/tasks_controller.rb spec/models/task_spec.rb`
- [ ] 実際にバリデーションエラーを含む CSV をブラウザからアップロードし、フラッシュメッセージが表示されること（手動確認）