### PR TITLE
ci: Brakeman セキュリティスキャンを追加

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -63,6 +63,8 @@ jobs:
         run: bun playwright install chromium
       - name: Bun
         run: bundle exec rails assets:precompile
+      - name: Brakeman Security Scan
+        run: bundle exec brakeman --no-pager
       - name: rubocop
         run: bundle exec rubocop
       - name: tmp cache clear


### PR DESCRIPTION
## Summary
- CI ワークフロー (`.github/workflows/ruby.yml`) に `bundle exec brakeman --no-pager` ステップを追加し、PR ごとにセキュリティ問題を検出できるようにしました
- rubocop ステップの前に配置

closes #1554

## Test plan
- [x] GitHub Actions の Build ジョブで Brakeman ステップが成功すること
- [x] ローカルで `bundle exec brakeman --no-pager` を実行し警告 0 件を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CDパイプラインにセキュリティスキャンステップを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->