### PR TITLE
test: Admin users 削除テストの flaky を解消

### DIFF
--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -28,7 +28,7 @@ describe 'Admin Users管理機能', :js do
         within('tr', text: target_user.name) do
           click_link '削除'
         end
-        page.has_content?('ユーザ削除確認')
+        find('h1', text: 'ユーザ削除確認')
       end
 
       it '削除確認画面が表示される' do

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -28,6 +28,7 @@ describe 'Admin Users管理機能', :js do
         within('tr', text: target_user.name) do
           click_link '削除'
         end
+        expect(page).to have_content('ユーザ削除確認')
       end
 
       it '削除確認画面が表示される' do

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -28,11 +28,10 @@ describe 'Admin Users管理機能', :js do
         within('tr', text: target_user.name) do
           click_link '削除'
         end
-        expect(page).to have_content('ユーザ削除確認')
+        page.has_content?('ユーザ削除確認')
       end
 
       it '削除確認画面が表示される' do
-        expect(page).to have_content('ユーザ削除確認')
         expect(page).to have_content('削除します。よろしいですか？')
         expect(page).to have_content(target_user.name)
         expect(page).to have_content(target_user.email)


### PR DESCRIPTION
## Summary
- PR #1574 の rspec_job が `spec/system/admin/users_spec.rb:40` で `Playwright::Error: Element is not attached to the DOM` により失敗していた件の修正です。
- `before` ブロックで一覧の「削除」リンクをクリックした直後に本体の `click_link_or_button '削除'` が走ると、Turbo の DOM 入れ替え途中の要素を掴んでしまうレースが原因でした。
- `before` 末尾に `find('h1', text: 'ユーザ削除確認')` を追加し、確認画面の見出しが描画されるまで待ってからテスト本体に進むよう同期点を入れています (RuboCop の `RSpec/ExpectInHook` を避けつつ、要素が出ない場合は例外で明示的に落ちる形)。
- 同期点が確認画面の表示を保証するため、`it '削除確認画面が表示される'` 内の重複アサーションを削除しています。

## Test plan
- [x] `bundle exec rspec spec/system/admin/users_spec.rb` がローカルで全件パス (4 examples, 0 failures)
- [x] `bundle exec rubocop` がローカルで no offenses
- [x] CI (rspec_job) がグリーンになること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * ユーザー削除確認フローのテストケースを強化し、削除確認画面が正常に表示されることを確認するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->