### PR TITLE
Dependabot 自動マージの not a git repository エラーを修正

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Enable auto-merge
         run: |
-          gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+          gh pr merge --auto --squash --repo "$GH_REPO" "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 概要

Dependabot Auto Merge ワークフローの `auto-merge` ジョブが `fatal: not a git repository` で失敗していた問題を修正します（PR #1615 等で発生）。

## 原因

`gh pr merge` がカレントディレクトリに git リポジトリ（`.git`）を要求するが、ワークフローが `actions/checkout` を実行していないためエラーになっていた。

## 修正内容

- `gh pr merge` に `--repo "$GH_REPO"` を追加し、checkout なしでリポジトリを特定できるように
- PR番号・リポジトリ名を `env` 経由で渡すよう変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)