### PR TITLE
assets:precompile時のSass非推奨警告を解消

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,2 +1,2 @@
-@import 'bootstrap/scss/bootstrap';
-@import 'bootstrap-icons/font/bootstrap-icons';
+@use 'bootstrap/scss/bootstrap';
+@use 'bootstrap-icons/font/bootstrap-icons';

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "bun bun.config.js",
-    "build:css:compile": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules",
+    "build:css:compile": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --quiet-deps --load-path=node_modules",
     "build:css:prefix": "postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css",
     "build:css": "bun run build:css:compile && bun run build:css:prefix",
     "watch:css": "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \\\"bun run build:css\\\""


### PR DESCRIPTION
## 概要

CI の `assets:precompile` ステップで Dart Sass の非推奨警告が大量に出力されていた問題を解消します（[該当ジョブ](https://github.com/kaki-org/taskleaf/actions/runs/27447138442/job/81134549956?pr=1614)では20件表示＋255件省略）。

## 警告の内訳

- `[import]` — アプリ側 `application.bootstrap.scss` の `@import` 使用（Dart Sass 3.0.0 で削除予定）
- `[mixed-decls]` / `[color-functions]` / `[global-builtin]` — Bootstrap 5.3 内部の SCSS 由来

## 変更内容

- `application.bootstrap.scss` の `@import` を `@use` に移行
- `package.json` の `build:css:compile` に `--quiet-deps` を追加し、node_modules 配下の依存（Bootstrap）由来の警告を抑制（[Bootstrap 公式推奨の対処](https://getbootstrap.com/docs/5.3/getting-started/vite/)）

## 検証

- `bun run build:css` で警告 0 件を確認
- 生成される `application.css` が修正前とバイト単位で同一であることを確認
- `RAILS_ENV=production bundle exec rails assets:precompile` が exit 0・警告 0 件で完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * ビルドシステムの内部改善を実施しました。Sass の読み込み方式を最新のベストプラクティスに準拠するよう更新し、スタイルシートの処理を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->