### PR TITLE
Dependabot 自動マージのマージ方式を squash から merge commit に変更

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Enable auto-merge
         run: |
-          gh pr merge --auto --squash --repo "$GH_REPO" "$PR_NUMBER"
+          gh pr merge --auto --merge --repo "$GH_REPO" "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## 概要

Dependabot 自動マージのワークフロー（`.github/workflows/dependabot-auto-merge.yml`）が `--squash` を指定していたため、auto-merge ジョブが失敗していました。

```
GraphQL: Squash merges are not allowed on this repository. (mergePullRequest)
```

本リポジトリの許可マージ方式は merge commit のみ（squash・rebase は無効）のため、許可されている `--merge` に変更します。

## 変更点

- `gh pr merge --auto --squash` → `gh pr merge --auto --merge`

## 確認

- [失敗していた CI 実行](https://github.com/kaki-org/taskleaf/actions/runs/27446998218/job/81134116457?pr=1613)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係の自動マージワークフローを更新しました。プルリクエストのマージ戦略を変更し、自動マージ機能を維持しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->