### PR TITLE
本番デプロイのたびにdb:seedが実行される問題を修正

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -12,4 +12,3 @@ bundle exec rails assets:clean
 
 echo "db:migrate"
 bundle exec rails db:migrate
-bundle exec rails db:seed

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,19 +7,23 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+if Rails.env.production? && ENV['SEED_FORCE'] != 'true'
+  Rails.logger.warn 'Skipping seeds.rb in production (set SEED_FORCE=true to override).'
+  return
+end
+
 Rails.logger.debug 'Executing seeds.rb...'
-User.find_or_create_by!(email: 'admin@example.com') do |user|
+admin_password = ENV.fetch('SEED_ADMIN_PASSWORD', 'password')
+admin = User.find_or_create_by!(email: 'admin@example.com') do |user|
   user.name = 'admin'
   user.admin = true
-  user.password = 'password'
-  user.password_confirmation = 'password'
+  user.password = admin_password
+  user.password_confirmation = admin_password
 end
 50.times do |n|
-  Task.create!(
-    name: "テストタスク#{n + 1}",
-    description: "テストタスク#{n + 1}の詳細",
-    user_id: 1
-  )
+  Task.find_or_create_by!(name: "テストタスク#{n + 1}", user: admin) do |task|
+    task.description = "テストタスク#{n + 1}の詳細"
+  end
 end
 20.times do |n|
   Task.find_by(name: "テストタスク#{n + 1}").image.attach(
@@ -34,9 +38,8 @@ end
   end
 end
 100.times do |n|
-  Task.create!(
-    name: "テストタスク#{n + 1}",
-    description: "テストタスク#{n + 1}の詳細",
-    user_id: User.where(admin: false).ids.sample
-  )
+  Task.find_or_create_by!(name: "テストタスク#{n + 51}") do |task|
+    task.description = "テストタスク#{n + 51}の詳細"
+    task.user_id = User.where(admin: false).ids.sample
+  end
 end


### PR DESCRIPTION
## Summary

- 本番デプロイのたびに `db:seed` が無条件実行され、既知パスワード(`admin@example.com`/`password`)の管理者アカウントが作成・150件のテストタスクが増殖し続ける脆弱性(Issue #1689, 深刻度: high)を修正
- `bin/render-build.sh` から `db:seed` を削除し、本番デプロイフローから自動seed実行を排除
- `db/seeds.rb` に環境ガード(`Rails.env.production?` かつ `SEED_FORCE` 未指定時はスキップ)を追加し、admin パスワードをENV(`SEED_ADMIN_PASSWORD`)経由で供給可能にした上で、タスク生成を `find_or_create_by!` ベースに冪等化、`user_id: 1` のハードコードを除去

Closes #1689

## Test plan

- [x] `bundle exec rubocop db/seeds.rb` — no offenses detected
- [x] `bundle exec rspec` — 197 examples, 0 failures, 1 pending(既存の想定保留)
- [x] `RAILS_ENV=test bundle exec rails db:seed` を2回連続実行し、User/Task件数が増えないことを確認(User: 6, Task: 150で不変)
- [x] `RAILS_ENV=production` でseeds.rbをロードし、`Skipping seeds.rb in production` のログが出てDB書き込みが発生しないことを確認
- [x] `SEED_ADMIN_PASSWORD` を指定した場合にadminのパスワードへ反映されることを確認
