### PR TITLE
pgsqlコンテナのボリュームをPostgreSQL 18のレイアウトに対応させる

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [![Ruby](https://img.shields.io/badge/ruby-4.0.0-blue.svg)](https://www.ruby-lang.org/)
 [![Rails](https://img.shields.io/badge/rails-8.1.0-blue.svg)](https://rubyonrails.org/)
 [![Valkey](https://img.shields.io/badge/valkey-8.1.1-blue.svg)](https://github.com/valkey-io/valkey)
-[![PostgreSQL](https://img.shields.io/badge/postgresql-17.5-blue.svg)](https://www.postgresql.org)
+[![PostgreSQL](https://img.shields.io/badge/postgresql-18.4-blue.svg)](https://www.postgresql.org)
 
 ## Environments
 
@@ -60,6 +60,26 @@ rubymineの場合は環境変数に以下を指定しておく
 
 ```plain
 REDIS_PORT=16379;PGSQL_HOST=pgsql.lvh.me
+```
+
+## トラブルシューティング
+
+### pgsql コンテナが起動しない（PostgreSQL 18 移行）
+
+PostgreSQL 18 系イメージはデータをメジャーバージョン別サブディレクトリに配置する形式へ変更された（[docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)）。
+17 以前で初期化した `pgsql-data` ボリュームが残っていると、ログに以下が出て `pgsql` が起動しない。
+
+```plain
+Error: in 18+, these Docker images are configured to store database data in a
+       format which is compatible with "pg_ctlcluster" ...
+```
+
+ローカルの開発用データは seeds で再生成できるため、ボリュームを破棄して作り直す。
+
+```bash
+docker compose down -v            # pgsql-data を含むボリュームを破棄
+docker compose up -d pgsql redis
+RAILS_ENV=development bundle exec rails db:setup
 ```
 
 ## その他

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,9 @@ services:
     environment:
       POSTGRES_PASSWORD: secret
     volumes:
-      - pgsql-data:/var/lib/postgresql/data
+      # postgres:18+ はデータをメジャーバージョン別サブディレクトリに配置するため
+      # /var/lib/postgresql をマウントする（docker-library/postgres#1259）
+      - pgsql-data:/var/lib/postgresql
     ports:
       - "5432:5432"
 volumes:


### PR DESCRIPTION
Closes #1712

## 概要

`postgres:18` 系イメージのデータ配置形式変更（[docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)）に `docker-compose.yml` のマウントポイントが追従しておらず、`pgsql` コンテナが起動しない問題を修正します。

## 変更内容

### docker-compose.yml
```diff
     volumes:
-      - pgsql-data:/var/lib/postgresql/data
+      - pgsql-data:/var/lib/postgresql
```
postgres:18+ はデータを `/var/lib/postgresql/<major>/docker` のメジャーバージョン別サブディレクトリに配置します。マウント先を `/var/lib/postgresql` 直下にするのが公式イメージの想定で、将来のメジャーアップグレードで `pg_upgrade --link` が使える構成になります。

### README.md
- 既存開発者向けの復旧手順（トラブルシューティング節）を追記
- PostgreSQL バッジを実態に合わせて 17.5 → 18.4 に更新

既存の名前付きボリューム `pgsql-data` は旧レイアウトのまま残るため、マウントポイント変更だけでは自動移行されません。ローカル開発データは seeds で再生成できるため、`docker compose down -v` で作り直す手順を案内しています。

## 検証

ユーザーの既存ボリュームに触れないよう、別プロジェクト名の使い捨て compose スタックで検証しました。

```
$ docker compose -p tl1712verify up -d pgsql
$ docker compose -p tl1712verify exec pgsql pg_isready -U postgres
/var/run/postgresql:5432 - accepting connections

# データ配置が新レイアウトになっていることを確認
$ docker compose -p tl1712verify exec pgsql sh -c 'ls -d /var/lib/postgresql/*/'
/var/lib/postgresql/18/
$ ... cat /var/lib/postgresql/18/docker/PG_VERSION
18

# Rails からの接続確認
$ RAILS_ENV=test bundle exec rake db:drop db:create db:schema:load   # 成功
$ bundle exec rspec spec/models/task_spec.rb                          # 15 examples, 0 failures
$ bundle exec rubocop                                                 # 98 files, no offenses
```

検証後、使い捨てスタックは `down -v` で破棄済みです。

## スコープ外（別途）

- README 44行目 `docker compose up -d db redis` の `db` は実サービス名 `pgsql` の誤記です。本 Issue（ボリュームレイアウト非互換）とは独立した既存の別問題のため、本 PR では触れていません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - PostgreSQLの対応バージョンを17.5から18.4へ更新しました。
  - PostgreSQL 18移行時にデータベースコンテナが起動しない場合のトラブルシューティング手順を追加しました。

- **改善**
  - PostgreSQL 18以降に対応したデータ配置設定へ更新しました。
  - 既存データボリュームの再作成とデータベースセットアップ方法を案内しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->